### PR TITLE
Add transparent yellowfin login

### DIFF
--- a/misc/yf-login-test.bat
+++ b/misc/yf-login-test.bat
@@ -1,0 +1,18 @@
+@echo off
+rem This is a very poor excuse for a unit test, but by inspecting router-error.log
+rem while running this, we can at least stress some of the cache contention paths of
+rem the yellowfin transparent auth system.
+
+rem You must replace USERNAME:PASSWORD before running
+rem Also, you must set GOMAXPROCS=2 (or more) before launching the router
+
+rem ab -A USERNAME:PASSWORD -n 1000 -c 4 -s 5 -k http://localhost/yellowfin/#
+
+rem Inspect router-error.log, and you should expect to see a few cases of:
+rem "Backing off on yellowfin login: ...."
+rem Following by a single
+rem "Transparent login to yellowfin: ..."
+
+rem The point of this test is to stress that locking system
+rem I don't make it a unit test, because that would require mocking the auth service,
+rem and I just don't have the energy to set that up now.

--- a/router/auth.go
+++ b/router/auth.go
@@ -12,7 +12,8 @@ import (
 	"time"
 )
 
-/* Sample PureHub response:
+/*
+Sample PureHub response:
 {
 	"access_token": "a-long-token",
 	"token_type": "bearer",
@@ -27,20 +28,30 @@ type pureHubAuthResponse struct {
 	Expires     string `json:".expires"`
 }
 
+// This is stored in the 'value' part of targetPassThroughAuth.tokenMap
+// The key is the user identity
+type yellowfinToken struct {
+	JSESSIONID string
+	IPID       string
+}
+
 // Returns true if the request should continue to be passed through the router
-func authPassThrough(log *log.Logger, w http.ResponseWriter, req *http.Request, target *targetPassThroughAuth) bool {
+// If you return false, then you must already have sent an appropriate error response to 'w'.
+func authPassThrough(log *log.Logger, w http.ResponseWriter, req *http.Request, authData *imqsAuthResponse, target *targetPassThroughAuth) bool {
 	switch target.config.Type {
 	case AuthPassThroughNone:
 		return true
 	case AuthPassThroughPureHub:
 		return authInjectPureHub(log, w, req, target)
+	case AuthPassThroughYellowfin:
+		return authInjectYellowfin(log, w, req, authData, target)
 	default:
 		return true
 	}
 }
 
 func authInjectPureHub(log *log.Logger, w http.ResponseWriter, req *http.Request, target *targetPassThroughAuth) bool {
-	// The 'inject' function assumes you have obtained the lock on target.token
+	// The 'inject' function assumes you have obtained a lock (read or write) on "target.lock"
 	inject := func() {
 		req.Header.Set("Authorization", "Bearer "+target.token)
 	}
@@ -48,34 +59,31 @@ func authInjectPureHub(log *log.Logger, w http.ResponseWriter, req *http.Request
 	// Run with two attempts.
 	// First attempt is optimistic. We take the read lock, and inject the auth header if it is valid.
 	// On the second attempt we take the write lock, and generate a new token.
-	for try := 0; try < 2; try++ {
-		if try == 0 {
-			target.lock.RLock()
-		} else {
-			target.lock.Lock()
-		}
 
-		if target.token != "" && target.tokenExpires.After(time.Now()) {
-			inject()
-		} else if try == 1 {
-			// Acquire a new token
-			err := pureHubGetToken(log, target)
-			if err != nil {
-				log.Infof("Error acquiring PureHub authentication token: %v", err)
-				http.Error(w, err.Error(), http.StatusUnauthorized)
-				return false
-			}
-			log.Infof("Success acquiring PureHub authentication token")
-			inject()
-		}
-
-		if try == 0 {
-			target.lock.RUnlock()
-		} else {
-			target.lock.Unlock()
-		}
+	done := false
+	target.lock.RLock()
+	if target.token != "" && target.tokenExpires.After(time.Now()) {
+		done = true
+		inject()
 	}
-	return true
+	target.lock.RUnlock()
+	if done {
+		return true
+	}
+
+	// Acquire a new token
+	target.lock.Lock()
+	err := pureHubGetToken(log, target)
+	if err == nil {
+		log.Infof("Success acquiring PureHub authentication token")
+		inject()
+	} else {
+		log.Infof("Error acquiring PureHub authentication token: %v", err)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+	}
+	target.lock.Unlock()
+
+	return err != nil
 }
 
 func pureHubGetToken(log *log.Logger, target *targetPassThroughAuth) error {
@@ -103,5 +111,141 @@ func pureHubGetToken(log *log.Logger, target *targetPassThroughAuth) error {
 		return fmt.Errorf("%v: %v", resp.Status, err)
 	}
 	return err
+}
 
+func authInjectYellowfin(log *log.Logger, w http.ResponseWriter, req *http.Request, authData *imqsAuthResponse, target *targetPassThroughAuth) bool {
+	if authData == nil {
+		log.Errorf("For Yellowfin transparent authentication, you must also enforce authorization")
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return false
+	}
+
+	inject := func(tok *yellowfinToken) {
+		// During initial deployment of this feature, people will still have yellowfin cookies such as JSESSIONID
+		// lingering in their browser. We need to make sure that we're clobbering those here. So what we're doing here
+		// is discarding the cookies that the user sent from his browser.
+		orgCookies := req.Cookies()
+		req.Header.Del("Cookie")
+		// Add back all other cookies
+		for _, c := range orgCookies {
+			if c.Name != "JSESSIONID" && c.Name != "IPID" {
+				req.AddCookie(c)
+			}
+		}
+		// Inject our yellowfin cookies
+		req.AddCookie(&http.Cookie{
+			Name:  "JSESSIONID",
+			Value: tok.JSESSIONID,
+		})
+		req.AddCookie(&http.Cookie{
+			Name:  "IPID",
+			Value: tok.IPID,
+		})
+	}
+
+	// The acquisition of a new cookie is the somewhat nontrivial case,
+	// because we need to ensure that we don't try and log a person in from more than one
+	// concurrent thread.
+	for start := time.Now(); time.Now().Sub(start).Seconds() < 15; {
+		// -- Fetch cached token --
+		done := false
+		target.lock.RLock()
+		token_g := target.tokenMap[authData.Identity]
+		if token_g != nil {
+			done = true
+			inject(token_g.(*yellowfinToken))
+		}
+		target.lock.RUnlock()
+		if done {
+			return true
+		}
+
+		// -- Acquire new token --
+
+		// Acquire a lock on the USER who is trying to login to yellowfin
+		haveUserLock := false
+		target.lock.Lock()
+		if !target.tokenLock[authData.Identity] {
+			target.tokenLock[authData.Identity] = true
+			haveUserLock = true
+		}
+		target.lock.Unlock()
+
+		if haveUserLock {
+			token := authYellowfinLogin(log, w, req, authData)
+			if token != nil {
+				// Insert cached token
+				target.lock.Lock()
+				target.tokenMap[authData.Identity] = token
+				target.tokenLock[authData.Identity] = false
+				target.lock.Unlock()
+			} else {
+				// Give up, because login failed
+				target.lock.Lock()
+				target.tokenLock[authData.Identity] = false
+				target.lock.Unlock()
+				return false
+			}
+		} else {
+			// It's likely that by the time we wake up, our user will be logged in.
+			log.Infof("Backing off on yellowfin login: %v", authData.Identity)
+			time.Sleep(time.Millisecond * 50)
+		}
+	}
+
+	log.Errorf("High-level timeout while trying to login to yellowfin for: %v", authData.Identity)
+	http.Error(w, "Not authorized", http.StatusUnauthorized)
+
+	return false
+}
+
+func authYellowfinLogin(log *log.Logger, w http.ResponseWriter, req *http.Request, authData *imqsAuthResponse) *yellowfinToken {
+	authReq, err := ms_http.NewRequest("POST", imqsauth_url+"/login_yellowfin", nil)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return nil
+	}
+
+	headAuth := req.Header.Get("Authorization")
+	if headAuth != "" {
+		authReq.Header.Set("Authorization", headAuth)
+	}
+	cookieSession, _ := req.Cookie(imqsauth_cookie)
+	if cookieSession != nil {
+		authReq.AddCookie(copyCookieToMSHTTP(cookieSession))
+	}
+
+	authResp, err := ms_http.DefaultClient.Do(authReq)
+	if err != nil {
+		log.Errorf("Error logging in to yellowfin: (Transport error: %v)", err)
+		http.Error(w, err.Error(), http.StatusGatewayTimeout)
+		return nil
+	}
+	defer authResp.Body.Close()
+
+	if authResp.StatusCode != http.StatusOK {
+		log.Errorf("Error logging in to yellowfin (HTTP code: %v)", authResp.Status)
+		http.Error(w, authResp.Status, authResp.StatusCode)
+		return nil
+	}
+
+	token := &yellowfinToken{}
+	for _, c := range authResp.Cookies() {
+		switch c.Name {
+		case "JSESSIONID":
+			token.JSESSIONID = c.Value
+		case "IPID":
+			token.IPID = c.Value
+		}
+	}
+
+	if token.JSESSIONID != "" && token.IPID != "" {
+		log.Infof("Transparent login to yellowfin: %v", authData.Identity)
+		return token
+	}
+
+	log.Errorf("Error logging in to yellowfin. Not enough cookies. (JSESSIONID='%v' IPID='%v')", token.JSESSIONID, token.IPID)
+	http.Error(w, "Error loggin in to yellowfin", http.StatusInternalServerError)
+
+	return nil
 }

--- a/router/config.go
+++ b/router/config.go
@@ -41,6 +41,13 @@ Example configuration file:
 				"Username": "username@example.com",
 				"Password": "mypassword"
 			}
+		},
+		"YELLOWFIN": {											Demonstrates the "Yellowfin" transparent authentication system
+			"URL": "http://yellowfinserver.example.com",
+			"RequirePermission": "enabled",
+			"PassThroughAuth": {
+				"Type": "Yellowfin"
+			}
 		}
 	},
 	"Routes": {
@@ -48,7 +55,8 @@ Example configuration file:
 		"/themes/(.*)": "{MAPS}/theme/$1",						If you use a named target, like {MAPS}, then it must be the first part of the replacement string.
 		"/docs/(.*)": "https://docs.example.com/$1",
 		"/about/(.*)": "http://127.0.0.1:2001/$1",
-		"/3rdparty/(.*)": "{THIRDPARTY}/$1",					Transparent authentication
+		"/3rdparty/(.*)": "{THIRDPARTY}/$1",					Transparent authentication to PureHub
+		"/yellowfin/(.*)": "{YELLOWFIN}/$1",					Transparent authentication to Yellowfin
 		"/telemetry/(.*)": "ws://127.0.0.1:2001/$1",			Websocket target
 		"/(.*)": "http://127.0.0.1/www/$1"						This will end up catching anything that doesn't match one of the more specific routes
 	},
@@ -65,8 +73,9 @@ in terms of the number of slashes in the prefix, is 10. In other words prefixes 
 type AuthPassThroughType string
 
 const (
-	AuthPassThroughNone    AuthPassThroughType = ""
-	AuthPassThroughPureHub                     = "PureHub"
+	AuthPassThroughNone      AuthPassThroughType = ""
+	AuthPassThroughPureHub                       = "PureHub"
+	AuthPassThroughYellowfin                     = "Yellowfin"
 )
 
 type Config struct {


### PR DESCRIPTION
This is similar in nature to the way we login to PureHub. The yellowfin
case is slightly different though, because we need to maintain a per-user
table of sessions.
