### PR TITLE
Add SitePro passthrough basic auth 

### DIFF
--- a/router/auth.go
+++ b/router/auth.go
@@ -69,9 +69,16 @@ func authPassThrough(log *log.Logger, w http.ResponseWriter, req *http.Request, 
 		return authInjectPureHub(log, w, req, target)
 	case AuthPassThroughYellowfin:
 		return authInjectYellowfin(log, w, req, authData, target)
+	case AuthPassThroughSitePro:
+		return authInjectSitePro(log, w, req, target)
 	default:
 		return true
 	}
+}
+
+func authInjectSitePro(log *log.Logger, w http.ResponseWriter, req *http.Request, target *targetPassThroughAuth) bool {
+	req.SetBasicAuth(target.config.Username, target.config.Password)
+	return true
 }
 
 func authInjectPureHub(log *log.Logger, w http.ResponseWriter, req *http.Request, target *targetPassThroughAuth) bool {

--- a/router/config.go
+++ b/router/config.go
@@ -80,6 +80,7 @@ const (
 	AuthPassThroughNone      AuthPassThroughType = ""
 	AuthPassThroughPureHub                       = "PureHub"
 	AuthPassThroughYellowfin                     = "Yellowfin"
+	AuthPassThroughSitePro                       = "SitePro"
 )
 
 type Config struct {

--- a/router/url_translator.go
+++ b/router/url_translator.go
@@ -40,6 +40,9 @@ PureHub:
 Yellowfin:
 	tokenMap
 	tokenLock
+
+SitePro:
+	none
 */
 type targetPassThroughAuth struct {
 	lock         sync.RWMutex // Guards access to all state except for "config", which is immutable


### PR DESCRIPTION
The SitePro passthrough auth mode ignores the session cookie and always passes through the basic Authorization header with username and password. We could re-use the `session` cookie, but we're not required to stay logged into the system and requests would be quite low frequency, so think this is ok.
