### PR TITLE
TI-409: Add remote storate for user data

### DIFF
--- a/router/config.go
+++ b/router/config.go
@@ -81,6 +81,7 @@ const (
 	AuthPassThroughYellowfin                     = "Yellowfin"
 	AuthPassThroughSitePro                       = "SitePro"
 	AuthPassThroughECS                           = "ECS"
+	AuthPassThroughCouchDB                       = "CouchDB"
 	serviceConfigFileName                        = "router-config.json"
 	serviceConfigVersion                         = 1
 	serviceName                                  = "ImqsRouter"

--- a/router/url_translator.go
+++ b/router/url_translator.go
@@ -46,6 +46,9 @@ SitePro:
 
 ECS:
 	none
+
+CouchDB:
+	none
 */
 type targetPassThroughAuth struct {
 	lock         sync.RWMutex // Guards access to all state except for "config", which is immutable


### PR DESCRIPTION
The `authInjectCouchDB` function compares the userID from the authData object with the userID specified in the request path.  Only when these two are the same will the user be allowed to access the URL.  This is to prevent a user from getting and setting a different user's data.