### PR TITLE
PCS-1311 - Config service variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.sublime-workspace
 router/router-access-test.log
 router/router-error-test.log
+.idea

--- a/router/config.go
+++ b/router/config.go
@@ -204,3 +204,16 @@ func (c *Config) LoadString(json_config string) error {
 	}
 	return c.verify()
 }
+
+type ConfigServiceConfig struct {
+	Port            string
+}
+
+func GetConfigServiceUrl() string {
+	config := ConfigServiceConfig{}
+	err := serviceconfig.GetConfig("C:\\imqsbin\\static-conf\\config-service.json", "", 0, "", &config)
+	if err != nil {
+		fmt.Printf("Error reading config service url: %v", err)
+	}
+	return config.Port
+}

--- a/router/logic_test.go
+++ b/router/logic_test.go
@@ -31,7 +31,7 @@ func verifyRoute(t *testing.T, rs *routeSet, inUrl string, expectOutUrl string) 
 	}
 }
 
-func TestRouteMatching(t *testing.T) {
+func TestUnitRouteMatching(t *testing.T) {
 	// Various tests, including giving priority to longer matches
 	rs := routeSetFromConfig(t, `
 		{"Routes": {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -395,9 +395,7 @@ func wsServer(t *testing.T) {
 func TestUnitGetRouterFromConfigService(t *testing.T) {
 	t.Log("Testing: Retrieving router port from the config service, after router service startup")
 	expectedValue := "5002"
-	client := &http.Client{}
-	request, _ := http.NewRequest("GET", ConfigServiceUrl +"/config-service/variable/router_http_port", nil)
-	response, err := client.Do(request)
+	response, err := http.DefaultClient.Get(ConfigServiceUrl +"/config-service/variable/router_http_port")
 	if err != nil {
 		t.Errorf("Error getting router_http_port from config service: %v", err)
 		return
@@ -423,12 +421,10 @@ func TestUnitGetRouterFromConfigService(t *testing.T) {
 // Integration Tests
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-func TestIntegrationAddingPortToConfigService(t *testing.T) {
+func TestIntegrationRetrieveRouterPortFromConfigServiceAfterRouterStartup(t *testing.T) {
 	t.Log("Testing: Retrieving router port from the config service, after router service startup")
 	expectedValue := "5002"
-	client := &http.Client{}
-	request, _ := http.NewRequest("GET", "http://localhost:2010/config-service/variable/router_http_port", nil)
-	response, err := client.Do(request)
+	response, err := http.DefaultClient.Get("http://localhost:2010/config-service/variable/router_http_port")
 	if err != nil {
 		t.Errorf("Error getting router_http_port from config service")
 		return
@@ -439,7 +435,7 @@ func TestIntegrationAddingPortToConfigService(t *testing.T) {
 		t.Errorf("Error reading response data")
 		return
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		t.Errorf("Error response from config service: StatusCode: %v, Body: %v", response.StatusCode, string(body[:]))
 		return
 	}

--- a/router/server.go
+++ b/router/server.go
@@ -6,11 +6,13 @@ import (
 	"github.com/IMQS/serviceauth"
 	ms_http "github.com/MSOpenTech/azure-sdk-for-go/core/http"
 	// "github.com/cespare/hutil/apachelog" // Newer, but doesn't support websockets
+	"errors"
 	"github.com/IMQS/go-apachelog" // Older, but supports websockets. Forked to include time zone in access logs.
 	"github.com/IMQS/httpbridge/go/src/httpbridge"
 	"golang.org/x/net/websocket"
 	"gopkg.in/natefinch/lumberjack.v2"
 	"io"
+	"io/ioutil"
 	golog "log"
 	"net"
 	"net/http"
@@ -21,6 +23,8 @@ import (
 	"strings"
 	"time"
 )
+
+var ConfigServiceUrl = "http://localhost:2010"
 
 // Router Server
 type Server struct {
@@ -73,6 +77,15 @@ func NewServer(config *Config) (*Server, error) {
 	}
 	s.httpTransport.Proxy = func(req *ms_http.Request) (*url.URL, error) {
 		return s.translator.getProxy(s.errorLog, req.URL.Host)
+	}
+
+	// Add router port to the config service. This step is important, as all other services will depend on this
+	// port. It doesn't make sense to let the config service default the port for router to 80, because if the router
+	// is not running on 80, they will all fail anyway. Better to fail fast
+	err = s.addPortToConfigService()
+	if err != nil {
+		s.errorLog.Errorf("Error adding port to config service")
+		return nil, err
 	}
 
 	s.errorLog.Info("Router starting with:")
@@ -463,6 +476,25 @@ func (s *Server) runHttpBridgeServers() error {
 		}
 	}
 	return firstErr
+}
+
+func (s *Server) addPortToConfigService() error {
+	client := &http.Client{}
+	request, _ := http.NewRequest("PUT", ConfigServiceUrl + "/config-service/variable", strings.NewReader(fmt.Sprintf("{\"key\": \"%v\", \"value\": \"%v\"}", "router_http_port", s.configHttp.Port)))
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != 200 {
+		return errors.New(fmt.Sprintf("An error occurred adding port to config service system variables. Status Code: %v, Message: %v", response.StatusCode, string(body[:])))
+	}
+
+	return nil
 }
 
 func (s *Server) Pong(w http.ResponseWriter, req *http.Request) {

--- a/router/server.go
+++ b/router/server.go
@@ -24,7 +24,7 @@ import (
 	"time"
 )
 
-var ConfigServiceUrl = "http://localhost:2010"
+var ConfigServiceUrl string
 
 // Router Server
 type Server struct {
@@ -479,9 +479,11 @@ func (s *Server) runHttpBridgeServers() error {
 }
 
 func (s *Server) addPortToConfigService() error {
-	client := &http.Client{}
-	request, _ := http.NewRequest("PUT", ConfigServiceUrl + "/config-service/variable", strings.NewReader(fmt.Sprintf("{\"key\": \"%v\", \"value\": \"%v\"}", "router_http_port", s.configHttp.Port)))
-	response, err := client.Do(request)
+	if len(ConfigServiceUrl) == 0 {
+		ConfigServiceUrl = "http://" + GetConfigServiceUrl()
+	}
+	req, err := http.NewRequest("PUT", ConfigServiceUrl+"/config-service/variable", strings.NewReader(fmt.Sprintf("{\"key\": \"%v\", \"value\": \"%v\"}", "router_http_port", s.configHttp.Port)))
+	response, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -490,7 +492,7 @@ func (s *Server) addPortToConfigService() error {
 	if err != nil {
 		return err
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return errors.New(fmt.Sprintf("An error occurred adding port to config service system variables. Status Code: %v, Message: %v", response.StatusCode, string(body[:])))
 	}
 


### PR DESCRIPTION
Added different naming conventions to tests, so differentiate between unit
and integration tests. Added the ability for router to add its http_port
to config service. Added unit tests and integration tests, testing the
router adding its http port to the config sservice