### PR TITLE
Add UDP forwarding

### DIFF
--- a/router/udp.go
+++ b/router/udp.go
@@ -1,0 +1,59 @@
+package router
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+const udpConnectionLimit = 100
+
+type udpConnection struct {
+	net.Conn
+	sync.Mutex
+}
+
+// UDPConnectionPool is a connection pool for sending UDP requests
+type UDPConnectionPool struct {
+	pool map[string]*udpConnection
+	sync.Mutex
+}
+
+// NewUDPConnectionPool is a util method to construct a new UDPConnectionPool
+func NewUDPConnectionPool() *UDPConnectionPool {
+	return &UDPConnectionPool{pool: make(map[string]*udpConnection)}
+}
+
+func (p *UDPConnectionPool) getConnection(address string) (*udpConnection, error) {
+	p.Lock()
+	defer p.Unlock()
+	udpConn, ok := p.pool[address]
+	if !ok {
+		if len(p.pool) >= udpConnectionLimit {
+			return nil, fmt.Errorf("UDP connection pool limit reached")
+		}
+
+		fmt.Println("Adding UDP connection to UDP connection pool : ", address)
+		conn, err := net.Dial("udp", address)
+		if err != nil {
+			return nil, err
+		}
+
+		udpConn = &udpConnection{conn, sync.Mutex{}}
+		p.pool[address] = udpConn
+	}
+	return udpConn, nil
+}
+
+// Send sends a UDP request with msg as content to the specified address
+func (p *UDPConnectionPool) Send(address string, msg []byte) error {
+	udpConn, err := p.getConnection(address)
+	if err != nil {
+		return err
+	}
+
+	udpConn.Lock() // need to lock before writing to a UDP connection otherwise an additional ephemeral port get's consumed
+	_, err = udpConn.Write(msg)
+	udpConn.Unlock()
+	return err
+}

--- a/router/udp_test.go
+++ b/router/udp_test.go
@@ -1,0 +1,51 @@
+package router
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+var udpConnPool *UDPConnectionPool
+var wg sync.WaitGroup
+
+/*
+ * These tests do not actually launch a live router; they simply test the UDP connection pool.
+ * Since UDP requests are connectionless there is no need for a server component
+ */
+func send(t *testing.T, port, iMsg int) {
+	defer wg.Done()
+	msg := []byte(strconv.Itoa(iMsg))
+	address := fmt.Sprintf(":%v", port)
+	if err := udpConnPool.Send(address, msg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sendToPort(t *testing.T, port, nrMsgs int) {
+	defer wg.Done()
+	for i := 0; i < nrMsgs; i++ {
+		wg.Add(1)
+		go send(t, port, i)
+	}
+}
+
+func TestEphemeralPortExhaustion(t *testing.T) {
+	udpConnPool = NewUDPConnectionPool()
+
+	wg.Add(1)
+	go sendToPort(t, 8000, 200000)
+
+	for i := 8000; i < 8100; i++ {
+		wg.Add(1)
+		go sendToPort(t, i, 2000)
+	}
+
+	wg.Wait()
+
+	// connection pool is full, so this should error
+	if err := udpConnPool.Send(":8101", []byte("message")); err == nil {
+		t.Fatalf("Expected error: UDP connection pool limit reached")
+	}
+}

--- a/router/url_translator.go
+++ b/router/url_translator.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"fmt"
-	"github.com/IMQS/log"
 	"net/url"
 	"regexp"
 	"sort"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/IMQS/log"
 )
 
 type scheme string
@@ -20,6 +21,7 @@ const (
 	scheme_http              = "http"
 	scheme_https             = "https"
 	scheme_httpbridge        = "httpbridge"
+	scheme_udp               = "udp"
 )
 
 // A target URL
@@ -71,6 +73,8 @@ func parse_scheme(targetUrl string) scheme {
 	switch {
 	case targetUrl[0:3] == "ws:":
 		return scheme_ws
+	case targetUrl[0:4] == "udp:":
+		return scheme_udp
 	case targetUrl[0:5] == "http:":
 		return scheme_http
 	case targetUrl[0:6] == "https:":


### PR DESCRIPTION
Need this to forward Bucky metrics to Datadog UDP API. UDP is fire-and-forget so no harm done if Datadog is not installed.

Static conf changes: https://github.com/IMQS/static-conf/pull/52
www changes: https://github.com/IMQS/www/pull/1674